### PR TITLE
Improve ignored queries

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,3 +26,6 @@ Metrics/MethodLength:
 
 Style/ModuleFunction:
   EnforcedStyle: extend_self
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: consistent_comma

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "rspec", "~> 3.0"
 
 gem "rubocop", "~> 1.7"
 
-active_record_version = ENV.fetch("ACTIVE_RECORD_VERSION", "~> 4")
+active_record_version = ENV.fetch("ACTIVE_RECORD_VERSION", "~> 6")
 
 gem "activerecord", active_record_version
 gem "activesupport", active_record_version

--- a/lib/wt_activerecord_index_spy/notification_listener.rb
+++ b/lib/wt_activerecord_index_spy/notification_listener.rb
@@ -21,7 +21,8 @@ module WtActiverecordIndexSpy
       /^SELECT @@FOREIGN_KEY_CHECKS/,
       /^SET FOREIGN_KEY_CHECKS/,
       /^TRUNCATE TABLE/,
-      /^EXPLAIN/
+      /^EXPLAIN/,
+     /FROM INFORMATION_SCHEMA/,
     ].freeze
 
     attr_reader :queries_missing_index
@@ -44,7 +45,7 @@ module WtActiverecordIndexSpy
       identifier = values[:name]
 
       if ignore_query?(query: query, name: identifier)
-        logger.debug "query type ignored"
+        logger.debug "query type ignored, name: #{identifier}, query: #{query}"
         return
       end
       logger.debug "query type accepted"
@@ -88,7 +89,6 @@ module WtActiverecordIndexSpy
       # the query was cached
       name == "CACHE" ||
         name == "SCHEMA" ||
-        !name ||
         !query.downcase.include?("where") ||
         IGNORED_SQL.any? { |r| query =~ r }
     end

--- a/lib/wt_activerecord_index_spy/notification_listener.rb
+++ b/lib/wt_activerecord_index_spy/notification_listener.rb
@@ -22,7 +22,7 @@ module WtActiverecordIndexSpy
       /^SET FOREIGN_KEY_CHECKS/,
       /^TRUNCATE TABLE/,
       /^EXPLAIN/,
-     /FROM INFORMATION_SCHEMA/,
+      /FROM INFORMATION_SCHEMA/,
     ].freeze
 
     attr_reader :queries_missing_index

--- a/lib/wt_activerecord_index_spy/query_analyser/mysql.rb
+++ b/lib/wt_activerecord_index_spy/query_analyser/mysql.rb
@@ -9,7 +9,7 @@ module WtActiverecordIndexSpy
       ALLOWED_EXTRA_VALUES = [
         # https://bugs.mysql.com/bug.php?id=64197
         "Impossible WHERE noticed after reading const tables",
-        "no matching row"
+        "no matching row",
       ].freeze
 
       def analyse(results)

--- a/spec/lib/wt_activerecord_index_spy/aggregator_spec.rb
+++ b/spec/lib/wt_activerecord_index_spy/aggregator_spec.rb
@@ -51,7 +51,7 @@ module WtActiverecordIndexSpy
                                  ["certain"], ["bb"], ["SELECT 4"], ["popo.rb"],
                                  ["certain"], ["bb"], ["SELECT 41"], ["popo.rb"],
                                  ["certain"], ["cc"], ["SELECT 1"], ["popo.rb"],
-                                 ["uncertain"], ["bb"], ["SELECT 2"], ["lala.rb"]
+                                 ["uncertain"], ["bb"], ["SELECT 2"], ["lala.rb"],
                                ])
 
         expect(stdout_spy).to have_received(:puts).with(/Report exported to/)

--- a/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
+++ b/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
@@ -1,18 +1,23 @@
+# frozen_string_literal: true
+
 RSpec.describe WtActiverecordIndexSpy::NotificationListener do
-  it 'ignores queries to INFORMATION_SCHEMA', only: [:mysql2] do
+  it "ignores queries to INFORMATION_SCHEMA", only: [:mysql2] do
     aggregator = WtActiverecordIndexSpy::Aggregator.new
 
     WtActiverecordIndexSpy.watch_queries(aggregator: aggregator, ignore_queries_originated_in_test_code: false) do
-      ActiveRecord::Base.connection.query("SELECT count FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE name='log_lsn_checkpoint_age'")
+      ActiveRecord::Base.connection.query(
+        "SELECT count FROM INFORMATION_SCHEMA.INNODB_METRICS "\
+        "WHERE name='log_lsn_checkpoint_age'"
+      )
     end
 
     expect(aggregator.certain_results.count).to eq(0)
     expect(aggregator.uncertain_results.count).to eq(0)
   end
 
-  it 'does not ignore queries with empty identifier' do
+  it "does not ignore queries with empty identifier" do
     aggregator = WtActiverecordIndexSpy::Aggregator.new
-    User.create!(name: 'lala')
+    User.create!(name: "lala")
 
     WtActiverecordIndexSpy.watch_queries(aggregator: aggregator, ignore_queries_originated_in_test_code: false) do
       ActiveRecord::Base.connection.query(

--- a/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
+++ b/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe WtActiverecordIndexSpy::NotificationListener do
     expect(aggregator.uncertain_results.count).to eq(0)
   end
 
-  context 'when the adapter is mysql2' do
+  context "when the adapter is mysql2" do
     it "does not ignore queries with empty identifier", only: [:mysql2] do
       aggregator = WtActiverecordIndexSpy::Aggregator.new
       User.create!(name: "lala")
@@ -31,7 +31,7 @@ RSpec.describe WtActiverecordIndexSpy::NotificationListener do
     end
   end
 
-  context 'when the adapter is postgresql' do
+  context "when the adapter is postgresql" do
     it "does not ignore queries with empty identifier", only: [:postgresql] do
       aggregator = WtActiverecordIndexSpy::Aggregator.new
       User.create!(name: "lala")

--- a/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
+++ b/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
@@ -15,17 +15,35 @@ RSpec.describe WtActiverecordIndexSpy::NotificationListener do
     expect(aggregator.uncertain_results.count).to eq(0)
   end
 
-  it "does not ignore queries with empty identifier" do
-    aggregator = WtActiverecordIndexSpy::Aggregator.new
-    User.create!(name: "lala")
+  context 'when the adapter is mysql2' do
+    it "does not ignore queries with empty identifier", only: [:mysql2] do
+      aggregator = WtActiverecordIndexSpy::Aggregator.new
+      User.create!(name: "lala")
 
-    WtActiverecordIndexSpy.watch_queries(aggregator: aggregator, ignore_queries_originated_in_test_code: false) do
-      ActiveRecord::Base.connection.query(
-        "SELECT * from users where name like 'lala%'"
-      )
+      WtActiverecordIndexSpy.watch_queries(aggregator: aggregator, ignore_queries_originated_in_test_code: false) do
+        ActiveRecord::Base.connection.query(
+          "SELECT * from users where name like 'lala%'"
+        )
+      end
+
+      expect(aggregator.certain_results.count).to eq(1)
+      expect(aggregator.uncertain_results.count).to eq(0)
     end
+  end
 
-    expect(aggregator.certain_results.count).to eq(1)
-    expect(aggregator.uncertain_results.count).to eq(0)
+  context 'when the adapter is postgresql' do
+    it "does not ignore queries with empty identifier", only: [:postgresql] do
+      aggregator = WtActiverecordIndexSpy::Aggregator.new
+      User.create!(name: "lala")
+
+      WtActiverecordIndexSpy.watch_queries(aggregator: aggregator, ignore_queries_originated_in_test_code: false) do
+        ActiveRecord::Base.connection.query(
+          "SELECT * from users where name like 'lala%'"
+        )
+      end
+
+      expect(aggregator.certain_results.count).to eq(0)
+      expect(aggregator.uncertain_results.count).to eq(1)
+    end
   end
 end

--- a/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
+++ b/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe WtActiverecordIndexSpy::NotificationListener do
     aggregator = WtActiverecordIndexSpy::Aggregator.new
 
     WtActiverecordIndexSpy.watch_queries(aggregator: aggregator, ignore_queries_originated_in_test_code: false) do
-      ActiveRecord::Base.connection.query(
+      ActiveRecord::Base.connection.execute(
         "SELECT count FROM INFORMATION_SCHEMA.INNODB_METRICS "\
         "WHERE name='log_lsn_checkpoint_age'"
       )
@@ -21,7 +21,7 @@ RSpec.describe WtActiverecordIndexSpy::NotificationListener do
       User.create!(name: "lala")
 
       WtActiverecordIndexSpy.watch_queries(aggregator: aggregator, ignore_queries_originated_in_test_code: false) do
-        ActiveRecord::Base.connection.query(
+        ActiveRecord::Base.connection.execute(
           "SELECT * from users where name like 'lala%'"
         )
       end
@@ -37,7 +37,7 @@ RSpec.describe WtActiverecordIndexSpy::NotificationListener do
       User.create!(name: "lala")
 
       WtActiverecordIndexSpy.watch_queries(aggregator: aggregator, ignore_queries_originated_in_test_code: false) do
-        ActiveRecord::Base.connection.query(
+        ActiveRecord::Base.connection.execute(
           "SELECT * from users where name like 'lala%'"
         )
       end

--- a/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
+++ b/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe WtActiverecordIndexSpy::NotificationListener do
+  it 'ignores queries to INFORMATION_SCHEMA', only: [:mysql2] do
+    aggregator = WtActiverecordIndexSpy::Aggregator.new
+
+    WtActiverecordIndexSpy.watch_queries(aggregator: aggregator, ignore_queries_originated_in_test_code: false) do
+      ActiveRecord::Base.connection.query("SELECT count FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE name='log_lsn_checkpoint_age'")
+    end
+
+    expect(aggregator.certain_results.count).to eq(0)
+    expect(aggregator.uncertain_results.count).to eq(0)
+  end
+
+  it 'does not ignore queries with empty identifier' do
+    aggregator = WtActiverecordIndexSpy::Aggregator.new
+    User.create!(name: 'lala')
+
+    WtActiverecordIndexSpy.watch_queries(aggregator: aggregator, ignore_queries_originated_in_test_code: false) do
+      ActiveRecord::Base.connection.query(
+        "SELECT * from users where name like 'lala%'"
+      )
+    end
+
+    expect(aggregator.certain_results.count).to eq(1)
+    expect(aggregator.uncertain_results.count).to eq(0)
+  end
+end


### PR DESCRIPTION
## Description

Queries with no identifier were being ignored by the method `ignore_query?`.

This PR changes this method to consider them.

When I did it, I was forced to ignore queries that include `FROM INFORMATION_SCHEMA`.

This PR also changes the default ACTIVE_RECORD_VERSION to be 6. This helps developers who want to contribute to run the tests locally when using a new Ruby version.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I tested these modifications running the entire test suit in our application that already uses this gem.

I also added unit tests to cover the modifications. 

## Checklist:

- [x] My code follows the style guidelines set by rubocop
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
