### PR TITLE
Fix issue with missing identifier from ActiveRecord

### DIFF
--- a/lib/wt_activerecord_index_spy/notification_listener.rb
+++ b/lib/wt_activerecord_index_spy/notification_listener.rb
@@ -42,7 +42,7 @@ module WtActiverecordIndexSpy
     def call(_name, _start, _finish, _message_id, values)
       query = values[:sql]
       logger.debug "query: #{query}"
-      identifier = values[:name]
+      identifier = values[:name].to_s
 
       if ignore_query?(query: query, name: identifier)
         logger.debug "query type ignored, name: #{identifier}, query: #{query}"
@@ -70,7 +70,6 @@ module WtActiverecordIndexSpy
         origin: reduce_origin(origin),
         certainity_level: certainity_level
       )
-
       @aggregator.add(item)
     end
     # rubocop:enable Metrics/AbcSize

--- a/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
+++ b/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe WtActiverecordIndexSpy::NotificationListener do
 
   describe 'Identifier not provided by ActiveRecord' do
     let(:values) do
-      { sql: 'SELECT * FROM `users` WHERE `name` = "lala"' }
+      { sql: 'SELECT * FROM users WHERE name = "lala"' }
     end
 
     it 'defaults to empty string if identifier not provided' do

--- a/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
+++ b/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
@@ -15,13 +15,14 @@ RSpec.describe WtActiverecordIndexSpy::NotificationListener do
     expect(aggregator.uncertain_results.count).to eq(0)
   end
 
-  describe 'Identifier not provided by ActiveRecord' do    
-    let(:values) do 
-      { sql: 'SELECT * FROM `users` WHERE `name` = "lala"'}
+  describe 'Identifier not provided by ActiveRecord' do
+    let(:values) do
+      { sql: 'SELECT * FROM `users` WHERE `name` = "lala"' }
     end
 
     it 'defaults to empty string if identifier not provided' do
-      listener = WtActiverecordIndexSpy::NotificationListener.new(ignore_queries_originated_in_test_code: false, aggregator: aggregator)
+      listener = WtActiverecordIndexSpy::NotificationListener.new(ignore_queries_originated_in_test_code: false,
+                                                                  aggregator: aggregator)
       listener.call('name', 'start', 'finish', 'message_id', values)
       expect(aggregator.certain_results.count).to eq 1
       expect(aggregator.certain_results.first.identifier).to eq ''

--- a/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
+++ b/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
@@ -21,10 +21,8 @@ RSpec.describe WtActiverecordIndexSpy::NotificationListener do
       { sql: query }
     end
 
-  describe 'No identifier provided' do
     before(:each) do
-      listener = WtActiverecordIndexSpy::NotificationListener.new(ignore_queries_originated_in_test_code: false,
-      aggregator: aggregator)
+      listener = WtActiverecordIndexSpy::NotificationListener.new(ignore_queries_originated_in_test_code: false, aggregator: aggregator)
       listener.call('name', 'start', 'finish', 'message_id', values)
     end
 

--- a/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
+++ b/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe WtActiverecordIndexSpy::NotificationListener do
   let(:aggregator) { WtActiverecordIndexSpy::Aggregator.new }
+  let(:query) { "SELECT * from users where name like 'lala%'" }
 
   it "ignores queries to INFORMATION_SCHEMA", only: [:mysql2] do
     WtActiverecordIndexSpy.watch_queries(aggregator: aggregator, ignore_queries_originated_in_test_code: false) do
@@ -17,7 +18,7 @@ RSpec.describe WtActiverecordIndexSpy::NotificationListener do
 
   describe 'Identifier not provided by ActiveRecord' do
     let(:values) do
-      { sql: 'SELECT * FROM users WHERE name = "lala"' }
+      { sql: query }
     end
 
     it 'defaults to empty string if identifier not provided' do
@@ -33,9 +34,7 @@ RSpec.describe WtActiverecordIndexSpy::NotificationListener do
     it "does not ignore queries with empty identifier", only: [:mysql2] do
       User.create!(name: "lala")
       WtActiverecordIndexSpy.watch_queries(aggregator: aggregator, ignore_queries_originated_in_test_code: false) do
-        ActiveRecord::Base.connection.execute(
-          "SELECT * from users where name like 'lala%'"
-        )
+        ActiveRecord::Base.connection.execute(query)
       end
 
       expect(aggregator.certain_results.count).to eq(1)
@@ -48,9 +47,7 @@ RSpec.describe WtActiverecordIndexSpy::NotificationListener do
       User.create!(name: "lala")
 
       WtActiverecordIndexSpy.watch_queries(aggregator: aggregator, ignore_queries_originated_in_test_code: false) do
-        ActiveRecord::Base.connection.execute(
-          "SELECT * from users where name like 'lala%'"
-        )
+        ActiveRecord::Base.connection.execute(query)
       end
 
       expect(aggregator.certain_results.count).to eq(0)

--- a/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
+++ b/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
@@ -21,12 +21,23 @@ RSpec.describe WtActiverecordIndexSpy::NotificationListener do
       { sql: query }
     end
 
-    it 'defaults to empty string if identifier not provided' do
+  describe 'No identifier provided' do
+    before(:each) do
       listener = WtActiverecordIndexSpy::NotificationListener.new(ignore_queries_originated_in_test_code: false,
-                                                                  aggregator: aggregator)
+      aggregator: aggregator)
       listener.call('name', 'start', 'finish', 'message_id', values)
+    end
+
+    it 'defaults to empty string if identifier not provided (mysql)', only: [:mysql2] do
+      expect(aggregator.uncertain_results.count).to eq 0
       expect(aggregator.certain_results.count).to eq 1
       expect(aggregator.certain_results.first.identifier).to eq ''
+    end
+
+    it 'defaults to empty string (postgresql)', only: [:postgresql] do
+      expect(aggregator.certain_results.count).to eq 0
+      expect(aggregator.uncertain_results.count).to eq 1
+      expect(aggregator.uncertain_results.first.identifier).to eq ''
     end
   end
 

--- a/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
+++ b/spec/lib/wt_activerecord_index_spy/notification_listener_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe WtActiverecordIndexSpy::NotificationListener do
-  it "ignores queries to INFORMATION_SCHEMA", only: [:mysql2] do
-    aggregator = WtActiverecordIndexSpy::Aggregator.new
+  let(:aggregator) { WtActiverecordIndexSpy::Aggregator.new }
 
+  it "ignores queries to INFORMATION_SCHEMA", only: [:mysql2] do
     WtActiverecordIndexSpy.watch_queries(aggregator: aggregator, ignore_queries_originated_in_test_code: false) do
       ActiveRecord::Base.connection.execute(
         "SELECT count FROM INFORMATION_SCHEMA.INNODB_METRICS "\
@@ -15,11 +15,22 @@ RSpec.describe WtActiverecordIndexSpy::NotificationListener do
     expect(aggregator.uncertain_results.count).to eq(0)
   end
 
+  describe 'Identifier not provided by ActiveRecord' do    
+    let(:values) do 
+      { sql: 'SELECT * FROM `users` WHERE `name` = "lala"'}
+    end
+
+    it 'defaults to empty string if identifier not provided' do
+      listener = WtActiverecordIndexSpy::NotificationListener.new(ignore_queries_originated_in_test_code: false, aggregator: aggregator)
+      listener.call('name', 'start', 'finish', 'message_id', values)
+      expect(aggregator.certain_results.count).to eq 1
+      expect(aggregator.certain_results.first.identifier).to eq ''
+    end
+  end
+
   context "when the adapter is mysql2" do
     it "does not ignore queries with empty identifier", only: [:mysql2] do
-      aggregator = WtActiverecordIndexSpy::Aggregator.new
       User.create!(name: "lala")
-
       WtActiverecordIndexSpy.watch_queries(aggregator: aggregator, ignore_queries_originated_in_test_code: false) do
         ActiveRecord::Base.connection.execute(
           "SELECT * from users where name like 'lala%'"
@@ -33,7 +44,6 @@ RSpec.describe WtActiverecordIndexSpy::NotificationListener do
 
   context "when the adapter is postgresql" do
     it "does not ignore queries with empty identifier", only: [:postgresql] do
-      aggregator = WtActiverecordIndexSpy::Aggregator.new
       User.create!(name: "lala")
 
       WtActiverecordIndexSpy.watch_queries(aggregator: aggregator, ignore_queries_originated_in_test_code: false) do


### PR DESCRIPTION

## Description

If `ActiveRecord` does not provide an identifier this causes the output to fail. This update simply stringifies the identifier so a crash does not happen.

Fixes #19

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

* Locally using code which currently fails
* Unit test added

## Checklist:

- [x] My code follows the style guidelines set by rubocop
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
