### PR TITLE
Add information about automatically running index checks during rspec runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,36 @@ it 'uses an index for all the queries' do
 end
 ```
 
+#### Run for all rspec tests
+
+By adding the following to your `rspec` configuration the `have_used_db_indexes` will run on each individual test and error if an index has not been used:
+
+```ruby
+Rspec.configure do |config|
+  config.around(:each) do |example|
+    unless example.metadata[:skip_index_spy]
+      expect { example.run }.to(have_used_db_indexes)
+    else
+      example.run
+    end
+  end
+
+  config.after(:all) do
+    WtActiverecordIndexSpy.export_html_results
+  end
+end
+```
+
+If you wish to skip index checking for specific tests you can then annotate your test as follows:
+
+```ruby
+describe 'Will not check indexes', :skip_index_spy do
+# ...or...
+context 'Does not check indexes', :skip_index_spy do
+# ...or...
+it 'will not check indexes', :skip_index_spy do
+```
+
 ### 2 - Watching all queries from a start point
 
 Add this line to enable it:


### PR DESCRIPTION
## Description

Documentation update as suggested in #20 to let users know how to run the index checks for every `rspec` test and how to 

Fixes # (issue)

## Type of change

Documentation update

## How Has This Been Tested?

The suggestions documented as used in the [OLIO app](https://olioex.com) API `rspec` configuration.

## Checklist:

- [x] My code follows the style guidelines set by rubocop
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
